### PR TITLE
Contract runtime bugfixes

### DIFF
--- a/contract-runtime.ss
+++ b/contract-runtime.ss
@@ -325,7 +325,7 @@
 
 (def &read-published-data-to-mem
   (&begin ;; -- memaddr size
-   calldatapointer@ MLOAD DUP1 #|calldatapointer@|# DUP4 #|size|# +
+   calldatapointer@ MLOAD DUP1 #|calldatapointer@|# DUP4 #|size|# ADD
    ;; DUP1 CALLDATASIZE LT &require-not! ;;---we don't actually need to validate that: ethereum will pad with zeroes on overflow, and the rest of the program will see if it's valid.
    calldatapointer@ MSTORE SWAP1 CALLDATACOPY))
 


### PR DESCRIPTION
Fix for:
```
> (import :mukn/ethereum/assembly)
> (import :mukn/ethereum/contract-runtime)
> (assemble &read-published-data-to-mem)  
*** ERROR IN mukn/ethereum/assembly#&directives -- (Argument 1) NUMBER expected
(+
 '#<Assembler #50 segment: #<Segment #51 bytes: #u8(96 32 81 128 131 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 ... #50
)
```

And: 
```
> (import :mukn/ethereum/assembly)
> (import :mukn/ethereum/contract-runtime)
> (assemble &ecrecover0)  
*** ERROR IN mukn/ethereum/assembly#&directives -- invalid directive #!unbound2
```
