### PR TITLE
Fix timeout check

### DIFF
--- a/contract-runtime.ss
+++ b/contract-runtime.ss
@@ -542,12 +542,10 @@
 
 ;; abort unless saved data indicates a timeout
 ;; TESTING STATUS: Used by buy-sig. Incompletely untested.
-(def (&check-timeout!) ;; -->
+(def (&check-timeout! timeout: (timeout (ethereum-timeout-in-blocks))) ;; -->
   (&begin
-   ;; TODO: negotiate the timeout between users,
-   ;; rather than hard-wiring it to the network as below?
-   (ethereum-timeout-in-blocks) timer-start ADD ;; using &safe-add is probably redundant there.
-   NUMBER LT &require-not!))
+   timeout timer-start ADD ;; using &safe-add is probably redundant there.
+   NUMBER LT &require!))
 
 ;; BEWARE! This is for two-participant contracts only,
 ;; where all the money is on the table, no other assets than Ether.

--- a/contract-runtime.ss
+++ b/contract-runtime.ss
@@ -545,7 +545,7 @@
 (def (&check-timeout! timeout: (timeout (ethereum-timeout-in-blocks))) ;; -->
   (&begin
    timeout timer-start ADD ;; using &safe-add is probably redundant there.
-   NUMBER LT &require!))
+   NUMBER GT &require-not!))
 
 ;; BEWARE! This is for two-participant contracts only,
 ;; where all the money is on the table, no other assets than Ether.


### PR DESCRIPTION
Also allows the timeout to be parameterized rather than hard-coded to the network config.