### PR TITLE
Add Watch integration test

### DIFF
--- a/t/70-watch-integrationtest.ss
+++ b/t/70-watch-integrationtest.ss
@@ -3,12 +3,48 @@
 (import
   :std/srfi/1 :std/test
   :clan/debug :clan/poo/poo
-  ../watch ../json-rpc ../nonce-tracker ../testing
-  ./30-transaction-integrationtest)
+  ../watch ../json-rpc ../nonce-tracker ../tx-tracker  ../transaction ../batch-call ../ethereum
+  ./signing-test ./30-transaction-integrationtest)
+
+(def (process-filter filter)
+  (display filter))
 
 (def 70-watch-integrationtest
   (test-suite "integration test for ethereum/watch"
     (reset-nonce croesus) (DBG nonce: (peek-nonce croesus))
-    (test-case "foo"
-;;XXX
-      (void))))
+    (def trivial-logger (.@ (ensure-trivial-logger-contract croesus) contract-address))
+    (test-case "watch-contract-step-normal-case"
+      (def receipt (post-transaction (call-function croesus trivial-logger (string->bytes "hello, world"))))  
+      (def current-block (eth_blockNumber))
+      (if (successful-receipt? receipt)
+           (let ((values a b) (watch-contract-step trivial-logger current-block (+ current-block 10) confirmations: 1))
+              (check-equal? (null? a) #f))))
+
+    (test-case "watch-contract-step-spurious from-block"
+      (def current-block (eth_blockNumber))
+      (def to-block (+ current-block 10)) ;;I made up 10
+      (def receipt (post-transaction (call-function croesus trivial-logger (string->bytes "hello, world"))))  
+      (if (successful-receipt? receipt)
+        (let ((values a b) (watch-contract-step trivial-logger (+ current-block 20) to-block confirmations: 1))
+            (check-equal? b to-block)
+            (check-equal? (null? a) #t))))
+
+    (test-case "watch-contract"
+      (def current-block (eth_blockNumber))
+      (def to-block (+ current-block 10)) ;;I made up 10
+      (def present-block current-block)
+      (def receipt (post-transaction (call-function croesus trivial-logger (string->bytes "hello, world"))))
+      (if (successful-receipt? receipt)
+       (begin
+         (watch-contract identity trivial-logger current-block to-block confirmations: 1)
+         (check-equal? (- (eth_blockNumber) 1) to-block))))
+    ;(test-case "watchBlockchain"
+      ;(def fromBlock (eth_blockNumber))
+      ;(def receipt (batch-call croesus [[trivial-logger 0 (string->bytes "Nothing here")]
+      ;                                  [trivial-logger (wei<-gwei 1) (string->bytes "Just lost one gwei")]]))
+      ;(if (successful-receipt? receipt)
+       ; (begin
+        ;  (register-confirmed-event-hook "trivial-family" fromBlock  receipt process-filter)
+        ;  (watchBlockchain)
+        ;  (check-equal? (next-unprocessed-block)  (1+ fromBlock)))))
+          ))

--- a/t/70-watch-integrationtest.ss
+++ b/t/70-watch-integrationtest.ss
@@ -13,36 +13,38 @@
   (test-suite "integration test for ethereum/watch"
     (reset-nonce croesus) (DBG nonce: (peek-nonce croesus))
     (def trivial-logger (.@ (ensure-trivial-logger-contract croesus) contract-address))
-    (test-case "watch-contract-step-normal-case"
+    (test-case "watch-contract-step"
       (def current-block (eth_blockNumber))
-      (begin 
-        (debug-send-tx (call-function croesus trivial-logger (string->bytes "hello, world")))
-        (let ((values a b) (watch-contract-step trivial-logger current-block (+ current-block (* 4 (ethereum-confirmations-wanted-in-blocks))))) ;; Multiplication is there so that it would wait till the contract it completed if not it returns empty list.
-          (check-equal? (null? a) #f))))
+      (def target-block (+ current-block (* 4 (ethereum-confirmations-wanted-in-blocks))))    
+      (debug-send-tx (call-function croesus trivial-logger (string->bytes "hello, world")))
+      (let ((values a b) (watch-contract-step trivial-logger current-block target-block));; Multiplication is there so that it would wait till the contract it completed if not it returns empty list.
+        (check-equal? (null? a) #f)
+        (check-equal? (= b target-block) #f)
+        (check-equal?  (string=? (bytes->string (.@ (car a) data)) "hello, world") #t))
 
-    (test-case "watch-contract-step-spurious from-block"
-      (def current-block (eth_blockNumber))
-      (def to-block (+ current-block (ethereum-confirmations-wanted-in-blocks)))
-        (begin 
-        (debug-send-tx (call-function croesus trivial-logger (string->bytes "hello, world"))) 
-        (let ((values a b) (watch-contract-step trivial-logger to-block to-block ))
-            (check-equal? (null? a) #t))))
+      (def latest-block (eth_blockNumber))
+      (def to-block (+ latest-block (ethereum-confirmations-wanted-in-blocks)))     
+      (debug-send-tx (call-function croesus trivial-logger (string->bytes "hello, world"))) 
+      (let ((values a b) (watch-contract-step trivial-logger to-block latest-block))
+        (check-equal? (null? a) #t)
+        (check-equal? b latest-block)))
 
     (test-case "watch-contract"
       (def current-block (eth_blockNumber))
       (def to-block (+ current-block (ethereum-confirmations-wanted-in-blocks)))
       (def present-block current-block)
-       (begin
-         (debug-send-tx (call-function croesus trivial-logger (string->bytes "hello, world")))
-         (watch-contract identity trivial-logger current-block to-block)      
-            (check-equal? (= (eth_blockNumber) current-block) #f)))
-    ;(test-case "watchBlockchain"
-      ;(def fromBlock (eth_blockNumber))
-      ;(def receipt (batch-call croesus [[trivial-logger 0 (string->bytes "Nothing here")]
-      ;                                  [trivial-logger (wei<-gwei 1) (string->bytes "Just lost one gwei")]]))
-      ;(if (successful-receipt? receipt)
-       ; (begin
-        ;  (register-confirmed-event-hook "trivial-family" fromBlock  receipt process-filter)
-        ;  (watchBlockchain)
-        ;  (check-equal? (next-unprocessed-block)  (1+ fromBlock)))))
+        (debug-send-tx (call-function croesus trivial-logger (string->bytes "hello, world")))
+        (watch-contract identity trivial-logger current-block to-block)      
+          (check-equal? (= (eth_blockNumber) current-block) #f))
+#|          
+    (test-case "watchBlockchain"
+      (def fromBlock (eth_blockNumber))
+      (def receipt (batch-call croesus [[trivial-logger 0 (string->bytes "Nothing here")]
+                                        [trivial-logger (wei<-gwei 1) (string->bytes "Just lost one gwei")]]))
+      (if (successful-receipt? receipt)
+        (begin
+          (register-confirmed-event-hook "trivial-family" fromBlock  receipt process-filter)
+          (watchBlockchain)
+          (check-equal? (next-unprocessed-block)  (1+ fromBlock)))))
+|#
           ))


### PR DESCRIPTION
Add integration test to watch.ss functions. However, `watchBlockchain` function is not included.   I noticed that when test is running for several times  `watch-contract-step-normal-case`  produces inconsistent output. This is coming from the way gerbil aggressively performs constant  folding(my thought). It is something that  might need deep research to figure out.