### PR TITLE
Debug digest

### DIFF
--- a/assembly.ss
+++ b/assembly.ss
@@ -368,6 +368,7 @@
    ((procedure? directive) (directive a))
    ((pair? directive) (apply (car directive) a (cdr directive)))
    ((symbol? directive) (&push-label a directive))
+   ((boolean? directive) (if directive (&push a 1) (&push a 0)))
    ((member directive '(#f #!void ())) (void))
    (else (error "invalid directive" directive))))
 

--- a/contract-runtime.ss
+++ b/contract-runtime.ss
@@ -619,6 +619,6 @@
 (def (&digest<-tvps tvps)
   (&begin
    brk DUP1 DUP1 ;; -- bufptr bufstart bufstart ;; NB: an early DUP1 saves us swaps or reloads later.
-   (map (match <> ([t . v] (&marshal t v))) tvps)
+   (&begin* (map (match <> ([t . v] (&marshal t v))) tvps))
    SUB SWAP1 ;; -- bufstart bufwidth
    SHA3))

--- a/t/80-evm-eval-integrationtest.ss
+++ b/t/80-evm-eval-integrationtest.ss
@@ -1,8 +1,10 @@
 (export #t)
 
 (import
-  :std/test :clan/number
-  ../assembly
+  :gerbil/gambit/bits :gerbil/gambit/bytes :gerbil/gambit/ports
+  :std/iter :std/misc/bytes :std/test :clan/number
+  :clan/poo/io :clan/persist/content-addressing
+  ../assembly ../contract-runtime ../types
   ./signing-test
   ./10-json-rpc-integrationtest ./30-transaction-integrationtest ./50-batch-send-integrationtest)
 
@@ -15,7 +17,9 @@
       (def contract-bytes
         (assemble/bytes
           (&begin
-            42 (&mstoreat 0 1) 2 0 RETURN)))
+            42
+            (&mstoreat 0 1)
+            2 0 RETURN)))
       (def result (evm-eval/offchain alice contract-bytes))
       (def unmarshaled-result (nat<-bytes result))
       (check-equal? (* 42 256) unmarshaled-result))
@@ -27,8 +31,8 @@
             (&if (&begin 1 2 GT)
               (&begin 0)
               (&begin 1))
-            (&mstoreat 1 1)
-            2 0 RETURN)))
+            (&mstoreat 0 1)
+            1 0 RETURN)))
       (def result (evm-eval/offchain alice contract-bytes))
       (check-equal? 0 (nat<-bytes result)))
 
@@ -40,7 +44,38 @@
               [[0 [0]]
                [1 [1]]
                [2 [2]]])
-            (&mstoreat 1 1)
-            2 0 RETURN)))
+            (&mstoreat 0 1)
+            1 0 RETURN)))
       (def result (evm-eval/offchain alice contract-bytes))
-      (check-equal? 1 (nat<-bytes result)))))
+      (check-equal? 1 (nat<-bytes result)))
+
+    (test-case "digest works with single value"
+      (def digest-value
+        [[UInt256 . 7]])
+      (def contract-bytes
+        (assemble/bytes
+          (&begin
+            (&digest<-tvps digest-value)
+            (&mstoreat 0 32)
+            32 0 RETURN)))
+      (def result (evm-eval/offchain alice contract-bytes))
+      (check-equal? (digest digest-value) result))
+
+    (test-case "digest works with multiple values"
+      (def digest-value
+        [[UInt256 . 7]
+         [UInt256 . 21]])
+      (def contract-bytes
+        (assemble/bytes
+          (&begin
+            (&digest<-tvps digest-value)
+            (&mstoreat 0 32)
+            32 0 RETURN)))
+      (def result (evm-eval/offchain alice contract-bytes))
+      (check-equal? (digest digest-value) result))))
+
+(def (digest alst)
+  (def out (open-output-u8vector))
+  (for ((p alst))
+    (with (([t . v] p)) (marshal t v out)))
+  (digest<-bytes (get-output-u8vector out)))


### PR DESCRIPTION
Fixes a bug in `&digest<-tvps` and adds corresponding unit tests.

https://github.com/fare/gerbil-ethereum/commit/42e18f63a930afdfab6b4035e5d055772a96cccb is unrelated but needed for switch expressions with boolean case values. 