### PR TITLE
Fix tail call

### DIFF
--- a/assembly.ss
+++ b/assembly.ss
@@ -109,6 +109,7 @@
 (def (&type a type x)
   (&bytes a ((.@ type .bytes<-) x)))
 (def (&int a i (n-bytes (n-bytes<-n-bits (integer-length i))))
+  (assert! (<= (integer-length i) (* 8 n-bytes)))
   (segment-push-bytes! (Assembler-segment a) (bytes<-nat i n-bytes)))
 (def (&push a i (n-bytes (max 1 (n-bytes<-n-bits (integer-length i)))))
   (assert! (<= 1 n-bytes 32))

--- a/contract-runtime.ss
+++ b/contract-runtime.ss
@@ -459,10 +459,10 @@
    [&jumpdest 'tail-call] ;; -- Should we assume the frame is in place? should we accept next-frame-pc next-frame-start next-frame-width?
    ;; -- frame-length TODO: at standard place in frame, info about who is or isn't timing out
    ;; and/or make it a standard part of the cp0 calling convention to catch such.
-   (&read-published-datum 1) 'tail-call-body JUMPI
+   (&read-published-datum 1) ISZERO 'tail-call-body JUMPI
    frame@ SHA3 0 SSTORE
    'stop-contract-call
-   [&jumpi1 'commit-contract-call])) ;; update the state, then commit and finally stop
+   [&jump1 'commit-contract-call])) ;; update the state, then commit and finally stop
 
 ;; Logging the data, simple version, optimal for messages less than 6000 bytes of data.
 ;; TESTING STATUS: Used by buy-sig.

--- a/t/80-evm-eval-integrationtest.ss
+++ b/t/80-evm-eval-integrationtest.ss
@@ -4,7 +4,7 @@
   :gerbil/gambit/bits :gerbil/gambit/bytes :gerbil/gambit/ports
   :std/iter :std/misc/bytes :std/test :clan/number
   :clan/poo/io :clan/persist/content-addressing
-  ../assembly ../contract-runtime ../types
+  ../assembly ../contract-runtime ../types ../ethereum ../signing
   ./signing-test
   ./10-json-rpc-integrationtest ./30-transaction-integrationtest ./50-batch-send-integrationtest)
 
@@ -65,6 +65,25 @@
       (def digest-value
         [[UInt256 . 7]
          [UInt256 . 21]])
+      (def contract-bytes
+        (assemble/bytes
+          (&begin
+            (&digest<-tvps digest-value)
+            (&mstoreat 0 32)
+            32 0 RETURN)))
+      (def result (evm-eval/offchain alice contract-bytes))
+      (check-equal? (digest digest-value) result))
+
+    (test-case "digest works with realistic frame state"
+      (def digest-value
+        [[UInt16 . 1014]
+         [Block . 2185]
+         [Address . alice]
+         [Address . bob]
+         [Digest . #u8(99 29 22 99 149 169 218 44 150 207 223 114 84 92 253 163 49 233 56 120 20 117 144 222 173 81 88 153 240 137 9 49)]
+         [UInt256 . 1000000000]
+         [UInt256 . 26494137127516106733148689316263385574755820242808037201403224934424794788569]
+         [UInt256 . 1000000000]])
       (def contract-bytes
         (assemble/bytes
           (&begin


### PR DESCRIPTION
The jump condition for continuing to the next code block was inverted, and the jump for committing the contract call was conditional without there being any meaningful truth value put on the stack. Confirmed working for the simple case of committing after each code block, but yet to be tested for transactions that execute multiple code blocks.