### PR TITLE
Fix keypair JSON import

### DIFF
--- a/contract-config.ss
+++ b/contract-config.ss
@@ -50,9 +50,6 @@
   (def chain-config (contract-config<-creation-receipt
                      (eth_getTransactionReceipt (.@ config creation-hash))))
   ;; TODO: automatically implement equality for records, better than that.
-  (display-object-ln verify-contract-config: "\n"
-                     config: ContractConfig config "\n"
-                     chain-config: ContractConfig chain-config)
   (unless (equal? (bytes<- ContractConfig config)
                   (bytes<- ContractConfig chain-config))
     (error "Contract configuration not matched by on-chain transaction"

--- a/known-addresses.ss
+++ b/known-addresses.ss
@@ -34,7 +34,7 @@
 (def (import-keypair/json j)
   (assert! (equal? (sort (hash-keys j) string<?) '("address" "pubkey" "seckey")))
   (keypair (<-json Address (hash-get j "address"))
-           (<-json SecretKey (hash-get j "seckey"))
+           (<-json Bytes32 (hash-get j "seckey"))
            (<-json PublicKey (hash-get j "pubkey"))))
 ;;Why can't we do that???
 ;;(defmethod (@@method :pr Keypair)

--- a/signing.ss
+++ b/signing.ss
@@ -92,6 +92,8 @@
    .element?: address?
    .json<-: 0x<-address
    .<-json: (compose make-address (.@ Bytes20 .<-json))
+   .string<-: 0x<-address
+   .<-string: address<-0x
    .sexp<-: (lambda (x) `(address<-0x ,(0x<-address x)))
    .<-bytes: (compose make-address (.@ Bytes20 .validate))
    .bytes<-: address-bytes

--- a/types.ss
+++ b/types.ss
@@ -74,6 +74,8 @@
 (.def (UInt. @ [poo.UInt.] .length-in-bits .length-in-bytes .validate)
   .json<-: 0x<-nat
   .<-json: (compose .validate number<-json)
+  .string<-: number->string
+  .<-string: string->number
   .rlp<-: rlp<-nat
   .<-rlp: (compose .validate nat<-rlp)
   .ethabi-name: (format "uint~d" .length-in-bits)
@@ -112,6 +114,7 @@
   .sexp<-: (lambda (x) `(bytes<-0x ,(0x<-bytes x)))
   .json<-: 0x<-bytes
   .<-json: (compose .validate bytes<-0x)
+  .<-string: bytes<-0x
   .rlp<-: identity
   .<-rlp: .validate
   .ethabi-padding: (- 32 n)


### PR DESCRIPTION
Uses `Bytes32` instead of `SecretKey` since JSON marshaling is explicitly disabled by `SecretKey`.

Also removes some leftover debug logs.