### PR TITLE
Fix a bug in &check-timeout!

### DIFF
--- a/evm-runtime.ss
+++ b/evm-runtime.ss
@@ -587,7 +587,7 @@
 (def (&check-timeout! timeout: (timeout (ethereum-timeout-in-blocks))) ;; -->
   (&begin
    timeout timer-start ADD ;; using &safe-add is probably redundant there.
-   NUMBER GT &require-not!))
+   NUMBER GT &require!))
 
 ;; BEWARE! This is for two-participant contracts only,
 ;; where all the money is on the table, no other assets than Ether.


### PR DESCRIPTION
Per the comment, this is supposed to assert that there *is* a timeout,
but the existing code asserts that there *is not* a timeout. This was
one of several issues I ran into implementing the escrow timeout for
glow.