### PR TITLE
Be stricter about checking the deposited amount.

### DIFF
--- a/evm-runtime.ss
+++ b/evm-runtime.ss
@@ -308,11 +308,11 @@
 ;; TESTING STATUS: Used by buy-sig
 (def &require! (&begin ISZERO &require-not!)) ;; [4B, 16G]
 
-;; Check the requirement that the amount actually deposited in the call (from CALLVALUE) is sufficient
-;; to cover the amount that the contract believes should have been deposited (from deposit@ MLOAD).
+;; Check the requirement that the amount actually deposited in the call (from CALLVALUE) matches
+;; the amount that the contract believes should have been deposited (from deposit@ MLOAD).
 ;; TESTING STATUS: Insufficiently tested
-(def &check-sufficient-deposit
-  (&begin deposit CALLVALUE LT &require-not!)) ;; [8B, 25G]
+(def &check-correct-deposit
+  (&begin deposit CALLVALUE EQ &require!)) ;; [8B, 25G]
 
 ;; TODO: *in the future*, have a variant of contracts that allows for posting markets,
 ;; whereby whoever posts the message to the blockchain might not be the participant,
@@ -475,7 +475,7 @@
 (def &define-simple-logging
   (&begin
    [&jumpdest 'commit-contract-call] ;; -- return-address
-   &check-sufficient-deposit ;; First, check deposit
+   &check-correct-deposit ;; First, check deposit
    calldatanew DUP1 CALLDATASIZE SUB ;; -- logsz cdn ret
    SWAP1 ;; -- cdn logsz ret
    DUP2 ;; logsz cdn logsz ret
@@ -489,7 +489,7 @@
 (def &define-variable-size-logging
   (&begin
    [&jumpdest 'commit-contract-call]
-   &check-sufficient-deposit ;; First, check the deposit
+   &check-correct-deposit ;; First, check the deposit
    ;; compute available buffer size: max(MSIZE, n*256)
    ;; -- TODO: find out the optimal number to minimize gas, considering the quadratic cost of memory
    ;; versus the affine cost of logging, and the cost of this loop.


### PR DESCRIPTION
Specifically, rather than demanding that the deposited amount is *at
least* what is expected, demand that it is *exactly* what is expected.

The rationale for this is that, when we move to multiplexing
interactions on a single contract:

- The interaction balance will have to be part of the merkelized state,
  since we can't query the VM for it.
- Therefore, participants will have to supply the correct value when
  restoring that state.
- So, if we allow participants to over-deposit, they could potentially
  throw off that value from what is expected, introducing a possible DoS
  vulnerability for the other participant unless we introduce some
  fiddly logic to deal with the possibility. It seems simpler to catch
  this up front.

I have confirmed that the downstream tests for glow still pass with this
change, in addition to the tests in this repo.