### PR TITLE
evm-runtime changes for glow #185

### DIFF
--- a/evm-runtime.ss
+++ b/evm-runtime.ss
@@ -473,10 +473,10 @@
    POP (&mloadat frame@ 2) JUMP
    ;; Should the "frame" below include the pc? the timer-start?
    [&jumpdest 'tail-call] ;; -- Should we assume the frame is in place? should we accept next-frame-pc next-frame-start next-frame-width?
-   &sync-deposit!
    ;; -- frame-length TODO: at standard place in frame, info about who is or isn't timing out
    ;; and/or make it a standard part of the cp0 calling convention to catch such.
    (&read-published-datum 1) ISZERO 'tail-call-body JUMPI
+   &sync-deposit!
    frame@ SHA3 0 SSTORE ;; TODO: ensure frame-width is on the stack before here
    'stop-contract-call
    [&jump1 'commit-contract-call])) ;; update the state, then commit and finally stop

--- a/evm-runtime.ss
+++ b/evm-runtime.ss
@@ -372,11 +372,7 @@
 (def &deposit!
   ;; Scheme pseudocode: (lambda (amount) (increment! deposit amount))
   ;; TODO: can we statically prove it's always within range and make the &safe-add an ADD ???
-  (&begin
-    DUP1
-    deposit &safe-add deposit-set!
-    ;; TODO(perf): defer adding deposit to the balance until transaction commit.
-    balance &safe-add balance-set!)) ;; [14B, 40G]
+  (&begin deposit &safe-add deposit-set!)) ;; [14B, 40G]
 
 ;; TESTING STATUS: Wholly untested.
 (def &send-ethers!
@@ -477,12 +473,18 @@
    POP (&mloadat frame@ 2) JUMP
    ;; Should the "frame" below include the pc? the timer-start?
    [&jumpdest 'tail-call] ;; -- Should we assume the frame is in place? should we accept next-frame-pc next-frame-start next-frame-width?
+   &sync-deposit!
    ;; -- frame-length TODO: at standard place in frame, info about who is or isn't timing out
    ;; and/or make it a standard part of the cp0 calling convention to catch such.
    (&read-published-datum 1) ISZERO 'tail-call-body JUMPI
    frame@ SHA3 0 SSTORE ;; TODO: ensure frame-width is on the stack before here
    'stop-contract-call
    [&jump1 'commit-contract-call])) ;; update the state, then commit and finally stop
+
+;; add the deposit to our recorded interaction balance.
+(def &sync-deposit!
+  (&begin
+    deposit balance &safe-add balance-set!))
 
 ;; Logging the data, simple version, optimal for messages less than 6000 bytes of data.
 ;; TESTING STATUS: Used by buy-sig.


### PR DESCRIPTION
This patch makes changes to evm-runtime needed for glow issue 185, which I'll open a pr for shortly.

This does two things:

1. Stores the balance in a merkelized variable, instead of querying it via SELFBALANCE.
2. Always emulate SELFDESTRUCT, as in #36.

Exactly how to handle (2) is open for discussion, but I figured I'd open this now that I have something working and we can go from there.