### PR TITLE
Pass timeout arguments through to evm-runtime

### DIFF
--- a/evm-runtime.ss
+++ b/evm-runtime.ss
@@ -671,7 +671,7 @@
 
 ;; abort unless saved data indicates a timeout
 ;; TESTING STATUS: Used by buy-sig. Incompletely untested.
-(def (&check-timeout! timeout: timeout) ;; -->
+(def (&check-timeout! timeout) ;; -->
   (&begin
    timeout timer-start ADD ;; using &safe-add is probably redundant there.
    ;; TODO: should this be GT require or LT require-not?
@@ -680,8 +680,9 @@
 ;; BEWARE! This is for two-participant contracts only,
 ;; where all the money is on the table.
 ;; TESTING STATUS: Used by buy-sig. Incompletely untested.
+;; TODO: the timeout argument should be mandatory, the default is wrong
 (def (&define-check-participant-or-timeout assets-and-vars
-                                           timeout: timeout
+                                           timeout: (timeout (ethereum-timeout-in-blocks))
                                            debug: (debug #f))
   (&begin ;; obliged-actor@ other-actor@ ret@C --> other-actor@
    [&jumpdest 'check-participant-or-timeout]
@@ -689,7 +690,7 @@
    (&mload 20) CALLER EQ #|-- ok? other@ ret@C|# SWAP1 SWAP2 #|-- ret@C ok? other@ |#
    JUMPI ;; if the caller matches, return to the program. Jump or not, the stack is: -- other-actor@
    ;; TODO: support some amount being in escrow for the obliged-actor and returned to him
-   (&check-timeout! timeout: timeout)
+   (&check-timeout! timeout)
    (&mload 20) (&interaction-selfdestruct assets-and-vars))) ;; give all the money to the other guy.
 
 ;; BEWARE: this function passes the actors by address reference, not by address value

--- a/evm-runtime.ss
+++ b/evm-runtime.ss
@@ -2,7 +2,7 @@
 (import
   :gerbil/gambit/bits :gerbil/gambit/bytes :gerbil/gambit/exact
   :std/misc/number :std/sugar :std/iter
-  :clan/base :clan/number :clan/with-id :clan/debug
+  :clan/base :clan/number :clan/with-id
   :clan/poo/brace
   :clan/poo/object (only-in :clan/poo/mop Type)
   :clan/crypto/secp256k1
@@ -671,20 +671,17 @@
 
 ;; abort unless saved data indicates a timeout
 ;; TESTING STATUS: Used by buy-sig. Incompletely untested.
-;; TODO: is (ethereum-timeout-in-blocks) the right default?
-(def (&check-timeout! timeout: (timeout (ethereum-timeout-in-blocks))) ;; -->
-  (DBG er676: timeout (ethereum-timeout-in-blocks))
+(def (&check-timeout! timeout: timeout) ;; -->
   (&begin
    timeout timer-start ADD ;; using &safe-add is probably redundant there.
-   ;; TODO: press X to doubt: GT require vs LT require-not
+   ;; TODO: should this be GT require or LT require-not?
    NUMBER GT &require!))
 
 ;; BEWARE! This is for two-participant contracts only,
 ;; where all the money is on the table.
 ;; TESTING STATUS: Used by buy-sig. Incompletely untested.
-;; TODO: is (ethereum-timeout-in-blocks) the right default?
 (def (&define-check-participant-or-timeout assets-and-vars
-                                           timeout: (timeout (ethereum-timeout-in-blocks))
+                                           timeout: timeout
                                            debug: (debug #f))
   (&begin ;; obliged-actor@ other-actor@ ret@C --> other-actor@
    [&jumpdest 'check-participant-or-timeout]

--- a/watch.ss
+++ b/watch.ss
@@ -31,6 +31,7 @@
       confirmations: (confirmations (ethereum-confirmations-wanted-in-blocks)))
   (if (<= from-block to-block)
     (let ()
+      ;; TODO: press X to doubt
       (def current-block (wait-until-block (+ from-block confirmations)))
       (def confirmed-block (- current-block confirmations))
       ;; TODO: correctly process timeouts and/or overly long lists
@@ -50,6 +51,7 @@
   (while (<= from-block to-block)
     (let ()
       ;; Determine blocks to watch
+      ;; TODO: press X to doubt
       (def current-block (wait-until-block (+ from-block confirmations)))
       (def confirmed-block (- current-block confirmations))
       (def end-block (min to-block confirmed-block))

--- a/watch.ss
+++ b/watch.ss
@@ -31,7 +31,6 @@
       confirmations: (confirmations (ethereum-confirmations-wanted-in-blocks)))
   (if (<= from-block to-block)
     (let ()
-      ;; TODO: press X to doubt
       (def current-block (wait-until-block (+ from-block confirmations)))
       (def confirmed-block (- current-block confirmations))
       ;; TODO: correctly process timeouts and/or overly long lists
@@ -51,7 +50,6 @@
   (while (<= from-block to-block)
     (let ()
       ;; Determine blocks to watch
-      ;; TODO: press X to doubt
       (def current-block (wait-until-block (+ from-block confirmations)))
       (def confirmed-block (- current-block confirmations))
       (def end-block (min to-block confirmed-block))


### PR DESCRIPTION
The `gerbil-ethereum` portion of the fix for https://github.com/Glow-Lang/glow/issues/413, which makes the `timeout:` keyword argument mandatory in `&check-timeout!` and `&define-check-participant-or-timeout`.

This PR goes with https://github.com/Glow-Lang/glow/pull/416