### PR TITLE
make-bytes fill 0

### DIFF
--- a/abi.ss
+++ b/abi.ss
@@ -98,7 +98,7 @@
   (def (set-tail! new-tail)
     (assert! (<= tail new-tail end))
     (set! tail new-tail))
-  (def bytes (make-bytes end))
+  (def bytes (make-bytes end 0))
   (subu8vector-move! prefix 0 prefix-length bytes 0)
   (ethabi-encode-into types xs bytes prefix-length prefix-length get-tail set-tail!)
   bytes)

--- a/assembly.ss
+++ b/assembly.ss
@@ -40,7 +40,7 @@
   transparent: #t)
 
 (def (new-segment (size max-segment-size))
-  (make-Segment (make-bytes size) 0))
+  (make-Segment (make-bytes size 0) 0))
 
 (def (segment-full? s)
   (>= (Segment-fill-pointer s) (bytes-length (Segment-bytes s))))

--- a/erc20.ss
+++ b/erc20.ss
@@ -14,7 +14,7 @@
 (import
   :gerbil/gambit/bits :gerbil/gambit/bytes
   :std/srfi/1 :std/sugar :std/iter
-  :clan/base :clan/with-id :clan/debug
+  :clan/base :clan/with-id :clan/assert
   :clan/poo/object (only-in :clan/poo/mop) :clan/poo/io
   ./logger ./hex ./types ./ethereum ./known-addresses ./abi ./json-rpc
   ./assembly ./transaction ./tx-tracker ./contract-config ./evm-runtime)
@@ -186,9 +186,7 @@
 (def (erc20-assert-log! receipt expectation)
   (def extracted-logs (map erc20-extracted-logger-log (.@ receipt logs)))
   (def expected (apply erc20-expected-logger-log expectation))
-  (unless (member expected extracted-logs)
-    (DBG erc20al190: expected extracted-logs expectation)
-    (assert! (member expected extracted-logs))))
+  (assert!! (member expected extracted-logs)))
 
 ;; : Void <- Address Address Address Address
 ;;This function sets the allowance by first checking whether the current allowance is 0, and if not, sets it to 0 before to change it to something else

--- a/erc20.ss
+++ b/erc20.ss
@@ -14,7 +14,7 @@
 (import
   :gerbil/gambit/bits :gerbil/gambit/bytes
   :std/srfi/1 :std/sugar :std/iter
-  :clan/base :clan/with-id :clan/assert
+  :clan/base :clan/with-id
   :clan/poo/object (only-in :clan/poo/mop) :clan/poo/io
   ./logger ./hex ./types ./ethereum ./known-addresses ./abi ./json-rpc
   ./assembly ./transaction ./tx-tracker ./contract-config ./evm-runtime)
@@ -186,7 +186,7 @@
 (def (erc20-assert-log! receipt expectation)
   (def extracted-logs (map erc20-extracted-logger-log (.@ receipt logs)))
   (def expected (apply erc20-expected-logger-log expectation))
-  (assert!! (member expected extracted-logs)))
+  (assert! (member expected extracted-logs)))
 
 ;; : Void <- Address Address Address Address
 ;;This function sets the allowance by first checking whether the current allowance is 0, and if not, sets it to 0 before to change it to something else

--- a/erc20.ss
+++ b/erc20.ss
@@ -14,7 +14,7 @@
 (import
   :gerbil/gambit/bits :gerbil/gambit/bytes
   :std/srfi/1 :std/sugar :std/iter
-  :clan/base :clan/with-id
+  :clan/base :clan/with-id :clan/debug
   :clan/poo/object (only-in :clan/poo/mop) :clan/poo/io
   ./logger ./hex ./types ./ethereum ./known-addresses ./abi ./json-rpc
   ./assembly ./transaction ./tx-tracker ./contract-config ./evm-runtime)
@@ -179,14 +179,16 @@
   [contract
     [event-signature
       (ethabi-encode [Address] [sender])
-      (ethabi-encode [Address] [recipient])] 
+      (ethabi-encode [Address] [recipient])]
     (ethabi-encode [UInt256] [amount])])
 
 ;; : Void <- TransactionReceipt [Listof Any]
 (def (erc20-assert-log! receipt expectation)
   (def extracted-logs (map erc20-extracted-logger-log (.@ receipt logs)))
   (def expected (apply erc20-expected-logger-log expectation))
-  (assert! (member expected extracted-logs)))
+  (unless (member expected extracted-logs)
+    (DBG erc20al190: expected extracted-logs expectation)
+    (assert! (member expected extracted-logs))))
 
 ;; : Void <- Address Address Address Address
 ;;This function sets the allowance by first checking whether the current allowance is 0, and if not, sets it to 0 before to change it to something else

--- a/erc721.ss
+++ b/erc721.ss
@@ -6,7 +6,7 @@
 (import
   :gerbil/gambit/bits :gerbil/gambit/bytes
   :std/srfi/1 :std/sugar
-  :clan/base :clan/with-id :clan/debug
+  :clan/base :clan/with-id :clan/assert
   :clan/poo/object (only-in :clan/poo/mop) :clan/poo/io
   ./logger ./hex ./types ./ethereum ./known-addresses ./abi ./json-rpc
   ./assembly ./transaction ./tx-tracker ./contract-config ./evm-runtime ./erc20)
@@ -75,9 +75,7 @@
 (def (erc721-assert-log! receipt expectation)
   (def extracted-logs (map erc721-extracted-logger-log (.@ receipt logs)))
   (def expected (apply erc721-expected-logger-log expectation))
-  (unless (member expected extracted-logs)
-    (DBG erc721al79: expected extracted-logs expectation)
-    (assert! (member expected extracted-logs))))
+  (assert!! (member expected extracted-logs)))
 
 ;; : Bool <- Address Address Address Bool
 (def (erc721-setApprovalForAll-expected-logger-log event-signature contract sender recipient approved)
@@ -91,9 +89,7 @@
 (def (erc721-setApprovalForAll-assert-log! receipt expectation)
   (def extracted-logs (map erc20-extracted-logger-log (.@ receipt logs)))
   (def expected (apply erc721-setApprovalForAll-expected-logger-log expectation))
-  (unless (member expected extracted-logs)
-    (DBG erc721safaal95: expected extracted-logs expectation)
-    (assert! (member expected extracted-logs))))
+  (assert!! (member expected extracted-logs)))
 
 ;;; Functions to interact with an ERC721 contract as a client
 

--- a/erc721.ss
+++ b/erc721.ss
@@ -6,7 +6,7 @@
 (import
   :gerbil/gambit/bits :gerbil/gambit/bytes
   :std/srfi/1 :std/sugar
-  :clan/base :clan/with-id :clan/assert
+  :clan/base :clan/with-id
   :clan/poo/object (only-in :clan/poo/mop) :clan/poo/io
   ./logger ./hex ./types ./ethereum ./known-addresses ./abi ./json-rpc
   ./assembly ./transaction ./tx-tracker ./contract-config ./evm-runtime ./erc20)
@@ -75,7 +75,7 @@
 (def (erc721-assert-log! receipt expectation)
   (def extracted-logs (map erc721-extracted-logger-log (.@ receipt logs)))
   (def expected (apply erc721-expected-logger-log expectation))
-  (assert!! (member expected extracted-logs)))
+  (assert! (member expected extracted-logs)))
 
 ;; : Bool <- Address Address Address Bool
 (def (erc721-setApprovalForAll-expected-logger-log event-signature contract sender recipient approved)
@@ -89,7 +89,7 @@
 (def (erc721-setApprovalForAll-assert-log! receipt expectation)
   (def extracted-logs (map erc20-extracted-logger-log (.@ receipt logs)))
   (def expected (apply erc721-setApprovalForAll-expected-logger-log expectation))
-  (assert!! (member expected extracted-logs)))
+  (assert! (member expected extracted-logs)))
 
 ;;; Functions to interact with an ERC721 contract as a client
 

--- a/erc721.ss
+++ b/erc721.ss
@@ -6,10 +6,10 @@
 (import
   :gerbil/gambit/bits :gerbil/gambit/bytes
   :std/srfi/1 :std/sugar
-  :clan/base :clan/with-id
+  :clan/base :clan/with-id :clan/debug
   :clan/poo/object (only-in :clan/poo/mop) :clan/poo/io
   ./logger ./hex ./types ./ethereum ./known-addresses ./abi ./json-rpc
-  ./assembly ./transaction ./tx-tracker ./contract-config ./evm-runtime ./erc20) 
+  ./assembly ./transaction ./tx-tracker ./contract-config ./evm-runtime ./erc20)
 
 
 (def totalSupply-selector ;;function totalSupply() external view returns (uint256)
@@ -75,7 +75,9 @@
 (def (erc721-assert-log! receipt expectation)
   (def extracted-logs (map erc721-extracted-logger-log (.@ receipt logs)))
   (def expected (apply erc721-expected-logger-log expectation))
-  (assert! (member expected extracted-logs)))
+  (unless (member expected extracted-logs)
+    (DBG erc721al79: expected extracted-logs expectation)
+    (assert! (member expected extracted-logs))))
 
 ;; : Bool <- Address Address Address Bool
 (def (erc721-setApprovalForAll-expected-logger-log event-signature contract sender recipient approved)
@@ -89,7 +91,9 @@
 (def (erc721-setApprovalForAll-assert-log! receipt expectation)
   (def extracted-logs (map erc20-extracted-logger-log (.@ receipt logs)))
   (def expected (apply erc721-setApprovalForAll-expected-logger-log expectation))
-  (assert! (member expected extracted-logs)))
+  (unless (member expected extracted-logs)
+    (DBG erc721safaal95: expected extracted-logs expectation)
+    (assert! (member expected extracted-logs))))
 
 ;;; Functions to interact with an ERC721 contract as a client
 

--- a/ethereum.ss
+++ b/ethereum.ss
@@ -69,7 +69,7 @@
 
 ;; Null address
 ;; : Address
-(def null-address (make-address (make-bytes 20)))
+(def null-address (make-address (make-bytes 20 0)))
 
 (defmethod (@@method :wr address)
   (lambda (self we)
@@ -100,13 +100,13 @@
    .ethabi-padding: (- 32 .length-in-bytes)
    .ethabi-tail-length: (lambda (_) 0)
    ;; https://docs.soliditylang.org/en/develop/abi-spec.html
-   ;; address: equivalent to uint160, except for the assumed interpretation and language typing. 
+   ;; address: equivalent to uint160, except for the assumed interpretation and language typing.
    ;; The above means left-padding with 0s
    .ethabi-encode-into:
    (lambda (x bytes start head get-tail set-tail!)
       (subu8vector-move! (address-bytes x) 0 .length-in-bytes bytes (+ head .ethabi-padding)))
    ;; https://docs.soliditylang.org/en/develop/abi-spec.html
-   ;; address: equivalent to uint160, except for the assumed interpretation and language typing. 
+   ;; address: equivalent to uint160, except for the assumed interpretation and language typing.
    ;; The above means left-padding with 0s
    .ethabi-decode-from:
    (lambda (bytes start head get-tail set-tail!)

--- a/known-addresses.ss
+++ b/known-addresses.ss
@@ -61,7 +61,7 @@
   (def len (string-length prefix))
   (unless (and (<= len 40) (string-every unhex* prefix))
     (error "Invalid keypair prefix" prefix))
-  (def p (make-bytes len))
+  (def p (make-bytes len 0))
   (for ((i (in-range len))) (bytes-set! p i (unhex (string-ref prefix i))))
   [(lambda (b)
      (let/cc return

--- a/shared-contract.md
+++ b/shared-contract.md
@@ -105,7 +105,7 @@ All state is asynchronous, and the last byte identifies the asynchronous state s
 - The global state would be under ID 0.
 
 - State associated to a particular user's balance would be at id
-  `(bytes-append (make-bytes 11) user-address #u8(1))`
+  `(bytes-append (make-bytes 11 0) user-address #u8(1))`
 
 - State associated to a user's allowance for another would be at
   `(bytes-replace (digest (Tuple Address Address) (vector from to)) 31 2)`

--- a/testing.ss
+++ b/testing.ss
@@ -219,7 +219,7 @@
    (bytes->string (.@ log data))])
 (def (expected-logger-log logger caller message)
   [(0x<-address logger)
-   [(json<- Bytes32 (bytes-append (make-bytes 12) (bytes<- Address caller)))]
+   [(json<- Bytes32 (bytes-append (make-bytes 12 0) (bytes<- Address caller)))]
    message])
 
 (def (expect-logger-logs receipt . expectations)


### PR DESCRIPTION
> If `fill` is omitted, the content of the vector is undefined.