### PR TITLE
import :std/assert

### DIFF
--- a/abi.ss
+++ b/abi.ss
@@ -11,7 +11,7 @@
 
 (import
   :gerbil/gambit/bytes
-  :std/misc/number :std/misc/process :std/misc/repr :std/srfi/1 :std/sugar
+  :std/misc/number :std/misc/process :std/misc/repr :std/srfi/1 :std/sugar :std/assert
   :clan/io :clan/poo/object :clan/poo/mop
   :clan/crypto/keccak)
 

--- a/abi.ss
+++ b/abi.ss
@@ -11,7 +11,7 @@
 
 (import
   :gerbil/gambit/bytes
-  :std/misc/number :std/misc/process :std/misc/repr :std/srfi/1 :std/sugar :std/assert
+  :std/assert :std/misc/number :std/misc/process :std/misc/repr :std/srfi/1 :std/sugar
   :clan/io :clan/poo/object :clan/poo/mop
   :clan/crypto/keccak)
 

--- a/assembly.ss
+++ b/assembly.ss
@@ -3,7 +3,7 @@
 (import
   :gerbil/gambit/bits :gerbil/gambit/bytes :gerbil/gambit/exact
   :std/srfi/1
-  :std/format :std/misc/bytes :std/misc/number :std/misc/hash :std/sugar
+  :std/format :std/misc/bytes :std/misc/number :std/misc/hash :std/sugar :std/assert
   :std/text/hex
   :clan/base :clan/number :clan/syntax
   :clan/poo/object :clan/poo/io

--- a/assembly.ss
+++ b/assembly.ss
@@ -2,8 +2,10 @@
 
 (import
   :gerbil/gambit/bits :gerbil/gambit/bytes :gerbil/gambit/exact
+  :std/assert :std/format
+  :std/misc/bytes :std/misc/hash :std/misc/number
   :std/srfi/1
-  :std/format :std/misc/bytes :std/misc/number :std/misc/hash :std/sugar :std/assert
+  :std/sugar
   :std/text/hex
   :clan/base :clan/number :clan/syntax
   :clan/poo/object :clan/poo/io

--- a/assets.ss
+++ b/assets.ss
@@ -4,7 +4,7 @@
 
 (export #t)
 (import
-  :std/sugar :std/format :std/misc/list :std/misc/string :std/misc/hash :std/srfi/1 :std/srfi/13 :std/iter
+  :std/sugar :std/assert :std/format :std/misc/list :std/misc/string :std/misc/hash :std/srfi/1 :std/srfi/13 :std/iter
   :clan/base :clan/basic-parsers :clan/decimal :clan/string
   :clan/poo/object
   ./assembly ./types ./ethereum ./abi ./evm-runtime ./network-config ./json-rpc ./erc20 ./simple-apps

--- a/assets.ss
+++ b/assets.ss
@@ -4,7 +4,10 @@
 
 (export #t)
 (import
-  :std/sugar :std/assert :std/format :std/misc/list :std/misc/string :std/misc/hash :std/srfi/1 :std/srfi/13 :std/iter
+  :std/assert :std/format :std/iter
+  :std/misc/hash :std/misc/list :std/misc/string
+  :std/srfi/1 :std/srfi/13
+  :std/sugar
   :clan/base :clan/basic-parsers :clan/decimal :clan/string
   :clan/poo/object
   ./assembly ./types ./ethereum ./abi ./evm-runtime ./network-config ./json-rpc ./erc20 ./simple-apps

--- a/erc20.ss
+++ b/erc20.ss
@@ -13,7 +13,9 @@
 
 (import
   :gerbil/gambit/bits :gerbil/gambit/bytes
-  :std/srfi/1 :std/sugar :std/assert :std/iter
+  :std/assert :std/iter
+  :std/srfi/1
+  :std/sugar
   :clan/base :clan/with-id
   :clan/poo/object (only-in :clan/poo/mop) :clan/poo/io
   ./logger ./hex ./types ./ethereum ./known-addresses ./abi ./json-rpc

--- a/erc20.ss
+++ b/erc20.ss
@@ -13,7 +13,7 @@
 
 (import
   :gerbil/gambit/bits :gerbil/gambit/bytes
-  :std/srfi/1 :std/sugar :std/iter
+  :std/srfi/1 :std/sugar :std/assert :std/iter
   :clan/base :clan/with-id
   :clan/poo/object (only-in :clan/poo/mop) :clan/poo/io
   ./logger ./hex ./types ./ethereum ./known-addresses ./abi ./json-rpc

--- a/erc721.ss
+++ b/erc721.ss
@@ -5,7 +5,9 @@
 
 (import
   :gerbil/gambit/bits :gerbil/gambit/bytes
-  :std/srfi/1 :std/sugar :std/assert
+  :std/assert
+  :std/srfi/1
+  :std/sugar
   :clan/base :clan/with-id
   :clan/poo/object (only-in :clan/poo/mop) :clan/poo/io
   ./logger ./hex ./types ./ethereum ./known-addresses ./abi ./json-rpc

--- a/erc721.ss
+++ b/erc721.ss
@@ -5,7 +5,7 @@
 
 (import
   :gerbil/gambit/bits :gerbil/gambit/bytes
-  :std/srfi/1 :std/sugar
+  :std/srfi/1 :std/sugar :std/assert
   :clan/base :clan/with-id
   :clan/poo/object (only-in :clan/poo/mop) :clan/poo/io
   ./logger ./hex ./types ./ethereum ./known-addresses ./abi ./json-rpc

--- a/evm-instructions.ss
+++ b/evm-instructions.ss
@@ -1,7 +1,9 @@
 (export #t)
 (import
   :gerbil/gambit/bits :gerbil/gambit/bytes
-  :std/misc/number :std/sugar :std/assert :std/misc/list :std/format
+  :std/assert :std/format
+  :std/misc/list :std/misc/number
+  :std/sugar
   :clan/base :clan/number :std/srfi/1
   :clan/poo/object (only-in :clan/poo/mop Type)
   (only-in :std/srfi/141 floor/)

--- a/evm-instructions.ss
+++ b/evm-instructions.ss
@@ -1,7 +1,7 @@
 (export #t)
 (import
   :gerbil/gambit/bits :gerbil/gambit/bytes
-  :std/misc/number :std/sugar :std/misc/list :std/format
+  :std/misc/number :std/sugar :std/assert :std/misc/list :std/format
   :clan/base :clan/number :std/srfi/1
   :clan/poo/object (only-in :clan/poo/mop Type)
   (only-in :std/srfi/141 floor/)

--- a/evm-instructions.ss
+++ b/evm-instructions.ss
@@ -3,10 +3,10 @@
   :gerbil/gambit/bits :gerbil/gambit/bytes
   :std/assert :std/format
   :std/misc/list :std/misc/number
+  :std/srfi/1 (only-in :std/srfi/141 floor/)
   :std/sugar
-  :clan/base :clan/number :std/srfi/1
+  :clan/base :clan/number
   :clan/poo/object (only-in :clan/poo/mop Type)
-  (only-in :std/srfi/141 floor/)
   ./assembly ./ethereum ./evm-runtime)
 
 ;; --------------------------------

--- a/evm-runtime.ss
+++ b/evm-runtime.ss
@@ -1,7 +1,7 @@
 (export #t)
 (import
   :gerbil/gambit/bits :gerbil/gambit/bytes :gerbil/gambit/exact
-  :std/misc/number :std/sugar :std/iter
+  :std/misc/number :std/sugar :std/assert :std/iter
   :clan/base :clan/number :clan/with-id
   :clan/poo/brace
   :clan/poo/object (only-in :clan/poo/mop Type)

--- a/evm-runtime.ss
+++ b/evm-runtime.ss
@@ -1,7 +1,9 @@
 (export #t)
 (import
   :gerbil/gambit/bits :gerbil/gambit/bytes :gerbil/gambit/exact
-  :std/misc/number :std/sugar :std/assert :std/iter
+  :std/assert :std/iter
+  :std/misc/number
+  :std/sugar
   :clan/base :clan/number :clan/with-id
   :clan/poo/brace
   :clan/poo/object (only-in :clan/poo/mop Type)

--- a/known-addresses.ss
+++ b/known-addresses.ss
@@ -2,7 +2,12 @@
 
 (import
   :gerbil/gambit/bits :gerbil/gambit/bytes :gerbil/gambit/random
-  :std/format :std/iter :std/misc/list :std/sort :std/srfi/13 :std/sugar :std/assert :std/text/hex
+  :std/assert :std/format :std/iter
+  :std/misc/list
+  :std/sort
+  :std/srfi/13
+  :std/sugar
+  :std/text/hex
   :clan/base :clan/json :clan/list :clan/number :clan/ports
   :clan/crypto/keccak
   :clan/poo/io :clan/poo/brace :clan/poo/object :clan/poo/debug

--- a/known-addresses.ss
+++ b/known-addresses.ss
@@ -2,7 +2,7 @@
 
 (import
   :gerbil/gambit/bits :gerbil/gambit/bytes :gerbil/gambit/random
-  :std/format :std/iter :std/misc/list :std/sort :std/srfi/13 :std/sugar :std/text/hex
+  :std/format :std/iter :std/misc/list :std/sort :std/srfi/13 :std/sugar :std/assert :std/text/hex
   :clan/base :clan/json :clan/list :clan/number :clan/ports
   :clan/crypto/keccak
   :clan/poo/io :clan/poo/brace :clan/poo/object :clan/poo/debug

--- a/presigned.ss
+++ b/presigned.ss
@@ -33,7 +33,10 @@
 
 (import
   :gerbil/gambit/bits :gerbil/gambit/bytes :gerbil/gambit/misc
-  :std/iter :std/text/hex :std/srfi/1 :std/sugar :std/assert
+  :std/assert :std/iter
+  :std/srfi/1
+  :std/sugar
+  :std/text/hex
   :clan/base :clan/number
   :clan/poo/object :clan/poo/brace :clan/poo/io
   :clan/crypto/secp256k1

--- a/presigned.ss
+++ b/presigned.ss
@@ -33,7 +33,7 @@
 
 (import
   :gerbil/gambit/bits :gerbil/gambit/bytes :gerbil/gambit/misc
-  :std/iter :std/text/hex :std/srfi/1 :std/sugar
+  :std/iter :std/text/hex :std/srfi/1 :std/sugar :std/assert
   :clan/base :clan/number
   :clan/poo/object :clan/poo/brace :clan/poo/io
   :clan/crypto/secp256k1

--- a/test-contracts.ss
+++ b/test-contracts.ss
@@ -5,7 +5,9 @@
 (import
   (for-syntax :std/misc/ports :std/text/hex :clan/path :clan/source)
   :gerbil/gambit/exceptions
-  :std/format :std/iter :std/sugar :std/assert :std/srfi/13
+  :std/assert :std/format :std/iter
+  :std/srfi/13
+  :std/sugar
   :clan/exception :clan/multicall :clan/path-config :clan/syntax
   :clan/poo/object :clan/poo/cli :clan/poo/debug
   :clan/persist/db

--- a/test-contracts.ss
+++ b/test-contracts.ss
@@ -5,7 +5,7 @@
 (import
   (for-syntax :std/misc/ports :std/text/hex :clan/path :clan/source)
   :gerbil/gambit/exceptions
-  :std/format :std/iter :std/sugar :std/srfi/13
+  :std/format :std/iter :std/sugar :std/assert :std/srfi/13
   :clan/exception :clan/multicall :clan/path-config :clan/syntax
   :clan/poo/object :clan/poo/cli :clan/poo/debug
   :clan/persist/db

--- a/testing.ss
+++ b/testing.ss
@@ -2,7 +2,7 @@
 
 (import
   :gerbil/gambit/bytes :gerbil/gambit/threads
-  :std/format :std/iter :std/misc/list :std/srfi/1 :std/srfi/13 :std/sugar :std/test
+  :std/format :std/iter :std/misc/list :std/srfi/1 :std/srfi/13 :std/sugar :std/assert :std/test
   :clan/base :clan/json :clan/multicall :clan/path-config :clan/syntax :clan/with-id
   :clan/poo/object :clan/poo/debug :clan/poo/brace :clan/poo/io
   ./types ./ethereum ./known-addresses ./abi ./logger

--- a/testing.ss
+++ b/testing.ss
@@ -2,7 +2,10 @@
 
 (import
   :gerbil/gambit/bytes :gerbil/gambit/threads
-  :std/format :std/iter :std/misc/list :std/srfi/1 :std/srfi/13 :std/sugar :std/assert :std/test
+  :std/assert :std/format :std/iter
+  :std/misc/list
+  :std/srfi/1 :std/srfi/13
+  :std/sugar :std/test
   :clan/base :clan/json :clan/multicall :clan/path-config :clan/syntax :clan/with-id
   :clan/poo/object :clan/poo/debug :clan/poo/brace :clan/poo/io
   ./types ./ethereum ./known-addresses ./abi ./logger

--- a/types.ss
+++ b/types.ss
@@ -7,7 +7,7 @@
   :gerbil/gambit/bits :gerbil/gambit/bytes :gerbil/gambit/exact
   :gerbil/gambit/hash :gerbil/gambit/ports
   :std/format :std/iter :std/misc/bytes :std/misc/completion :std/misc/hash :std/misc/list
-  :std/sort :std/srfi/1 :std/srfi/13 :std/srfi/43 :std/sugar :std/text/json
+  :std/sort :std/srfi/1 :std/srfi/13 :std/srfi/43 :std/sugar :std/assert :std/text/json
   :clan/base :clan/io :clan/json :clan/list
   :clan/maybe :clan/number :clan/syntax
   :clan/poo/object :clan/poo/io :clan/poo/rationaldict

--- a/types.ss
+++ b/types.ss
@@ -6,8 +6,12 @@
   (for-syntax :gerbil/gambit/exact :std/iter :std/stxutil :clan/syntax)
   :gerbil/gambit/bits :gerbil/gambit/bytes :gerbil/gambit/exact
   :gerbil/gambit/hash :gerbil/gambit/ports
-  :std/format :std/iter :std/misc/bytes :std/misc/completion :std/misc/hash :std/misc/list
-  :std/sort :std/srfi/1 :std/srfi/13 :std/srfi/43 :std/sugar :std/assert :std/text/json
+  :std/assert :std/format :std/iter
+  :std/misc/bytes :std/misc/completion :std/misc/hash :std/misc/list
+  :std/sort
+  :std/srfi/1 :std/srfi/13 :std/srfi/43
+  :std/sugar
+  :std/text/json
   :clan/base :clan/io :clan/json :clan/list
   :clan/maybe :clan/number :clan/syntax
   :clan/poo/object :clan/poo/io :clan/poo/rationaldict


### PR DESCRIPTION
After https://github.com/vyzo/gerbil/pull/644, `assert!` has been moved from `:std/sugar` to a new module `:std/assert`, so we need to import `:std/assert`.