### PR TITLE
Added RIN Ether asset to asset-table

### DIFF
--- a/assets.ss
+++ b/assets.ss
@@ -8,7 +8,7 @@
   :std/misc/hash :std/misc/list :std/misc/string
   :std/srfi/1 :std/srfi/13
   :std/sugar
-  :clan/base :clan/basic-parsers :clan/decimal :clan/string
+  :clan/base :clan/basic-parsers :clan/decimal :clan/string :clan/syntax
   :clan/poo/object
   ./assembly ./types ./ethereum ./abi ./evm-runtime ./network-config ./json-rpc ./erc20 ./simple-apps
   ./transaction ./tx-tracker)
@@ -228,3 +228,23 @@
   (for/collect ((p (hash->list/sort asset-table symbol<?))
                 when (equal? (asset->network (cdr p)) network))
     (cdr p)))
+
+
+
+
+
+;;~~~~~~~~~~~~~~~~~~~~~~ Add Native Currencies of ethereum-networks
+;;~~~~~~~~~~~~~~~~~~~~~~ to asset table.
+;;
+(def (register-native-asset _ network)
+  (hash-ensure-ref asset-table
+                   (.@ (.@ network nativeCurrency) symbol)
+                   (lambda ()
+                     (.def (nativeAsset @ Ether)
+                           .name: (.@ (.@ network nativeCurrency) name)
+                           .symbol: (.@ (.@ network nativeCurrency) symbol)
+                           .decimals: (.@ (.@ network nativeCurrency) decimals)
+                           .network: (symbolify (.@ network shortName)))
+                     nativeAsset)))
+
+(hash-for-each register-native-asset ethereum-networks)

--- a/assets.ss
+++ b/assets.ss
@@ -8,8 +8,8 @@
   :std/misc/hash :std/misc/list :std/misc/string
   :std/srfi/1 :std/srfi/13
   :std/sugar
-  :clan/base :clan/basic-parsers :clan/decimal :clan/string :clan/syntax
-  :clan/poo/object
+  :clan/base :clan/basic-parsers :clan/decimal :clan/string
+  :clan/poo/object :clan/poo/brace
   ./assembly ./types ./ethereum ./abi ./evm-runtime ./network-config ./json-rpc ./erc20 ./simple-apps
   ./transaction ./tx-tracker)
 
@@ -240,11 +240,10 @@
   (hash-ensure-ref asset-table
                    (.@ (.@ network nativeCurrency) symbol)
                    (lambda ()
-                     (.def (nativeAsset @ Ether)
+                     {(:: @ Ether)
                            .name: (.@ (.@ network nativeCurrency) name)
                            .symbol: (.@ (.@ network nativeCurrency) symbol)
                            .decimals: (.@ (.@ network nativeCurrency) decimals)
-                           .network: (symbolify (.@ network shortName)))
-                     nativeAsset)))
+                           .network: (string->symbol (.@ network shortName))})))
 
 (hash-for-each register-native-asset ethereum-networks)

--- a/assets.ss
+++ b/assets.ss
@@ -237,13 +237,14 @@
 ;;~~~~~~~~~~~~~~~~~~~~~~ to asset table.
 ;;
 (def (register-native-asset _ network)
+  (def nativeCurrency (.@ network nativeCurrency))
   (hash-ensure-ref asset-table
-                   (.@ (.@ network nativeCurrency) symbol)
+                   (.@ nativeCurrency symbol)
                    (lambda ()
                      {(:: @ Ether)
-                           .name: (.@ (.@ network nativeCurrency) name)
-                           .symbol: (.@ (.@ network nativeCurrency) symbol)
-                           .decimals: (.@ (.@ network nativeCurrency) decimals)
+                           .name: (.@ nativeCurrency name)
+                           .symbol: (.@ nativeCurrency symbol)
+                           .decimals: (.@ nativeCurrency decimals)
                            .network: (string->symbol (.@ network shortName))})))
 
 (hash-for-each register-native-asset ethereum-networks)

--- a/network-config.ss
+++ b/network-config.ss
@@ -166,7 +166,7 @@
 (def-eth-net (ropsten @ [shared-test-network has-etherscan has-infura])
   name: "Ethereum Testnet Ropsten"
   shortName: "rop" chain: "ETH" network: "ropsten" chainId: 3 networkId: 3
-  nativeCurrency: {name: "Ropsten Ether" symbol: "ROP" decimals: 18}
+  nativeCurrency: {name: "Ropsten Ether" symbol: 'ROP decimals: 18}
   faucets: ["https://faucet.ropsten.be/"
             "https://faucet.ropsten.be/donate/${ADDRESS}"]
   infoUrl: "https://github.com/ethereum/ropsten")

--- a/test-contracts.ss
+++ b/test-contracts.ss
@@ -132,6 +132,14 @@
   .decimals: 18
   .network: 'ced)
 
+(.def (RIN @ Ether)
+      .name: "RIN Ether"
+      .symbol: 'RIN
+      .decimals: 18
+      .network: 'rin)
+
+
+
 (for-each register-asset!
           [PET QASPET RBTPET
-           CED QASCED RBTCED])
+           CED QASCED RBTCED RIN])

--- a/test-contracts.ss
+++ b/test-contracts.ss
@@ -142,4 +142,5 @@
 
 (for-each register-asset!
           [PET QASPET RBTPET
-           CED QASCED RBTCED RIN])
+           CED QASCED RBTCED
+           RIN])

--- a/test-contracts.ss
+++ b/test-contracts.ss
@@ -92,11 +92,6 @@
      (error "fail!")))
   (assert! (equal? (eth_getTransactionCount initializer) 3)))
 
-(.def (PET @ Ether)
-  .name: "PET Ether"
-  .symbol: 'PET
-  .decimals: 18
-  .network: 'pet)
 
 (.def (QASPET @ ERC20)
   .contract-address: QASPET@
@@ -112,12 +107,6 @@
   .decimals: 18
   .network: 'pet)
 
-(.def (CED @ Ether)
-  .name: "CED Ether"
-  .symbol: 'CED
-  .decimals: 18
-  .network: 'ced)
-
 (.def (QASCED @ ERC20)
   .contract-address: QASCED@
   .name: "Quality Assurance Specie on Private Ethereum Testnet"
@@ -132,15 +121,7 @@
   .decimals: 18
   .network: 'ced)
 
-(.def (RIN @ Ether)
-      .name: "RIN Ether"
-      .symbol: 'RIN
-      .decimals: 18
-      .network: 'rin)
-
-
 
 (for-each register-asset!
-          [PET QASPET RBTPET
-           CED QASCED RBTCED
-           RIN])
+          [QASPET RBTPET
+           QASCED RBTCED])


### PR DESCRIPTION
# Overview

This adds the Rinkeby Ether asset to the asset-table. This allows for glow users to select the RIN Ether asset when using the Rinkeby shared test network

This is to address https://github.com/Glow-Lang/glow/issues/438